### PR TITLE
chore(README): Remove official contact options

### DIFF
--- a/packages/clerk-solidjs/README.md
+++ b/packages/clerk-solidjs/README.md
@@ -222,10 +222,8 @@ export {};
 
 You can get in touch in any of the following ways:
 
-- Join the Clerk official community [Discord server](https://clerk.com/discord)
 - Create a [GitHub Issue](https://github.com/spirit-led-software/clerk-solidjs/issues)
 - Create a [GitHub Discussion](https://github.com/spirit-led-software/clerk-solidjs/discussions)
-- Contact options listed on [the Clerk Support page](https://clerk.com/support?utm_source=github&utm_medium=clerk_solidjs)
 
 ## Contributing
 


### PR DESCRIPTION
Hello! Clerk employee here 👋 
Thank you for working on this!

Currently the README can give the impression to users that they can expect official support in Discord and through our support platform. As we don't offer that for community SDKs I'm removing said portions from the README so that it's clearer.

Hope that makes sense! Cheers 😊 